### PR TITLE
MethodDefinitions use the IdentifierName production, not Identifier

### DIFF
--- a/index.html
+++ b/index.html
@@ -348,7 +348,7 @@ let options = {
             <li>constructor</li>
             <li>set</li>
           </ul>
-          <h2 class="response fragment">Private</h2>
+          <h2 class="response fragment">None of the above!</h2>
         </section>
 
         <section>


### PR DESCRIPTION
So, method names are not restricted to not including strict FutureReservedWords. So, the ClassElementList may contain a MethodDefinition whose PropertyName is "private" --- However, a method body may not declare a variable named `private`, which is a slightly different thing
